### PR TITLE
Add libncurses5-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ RUN apt-get update \
     libasound2-dev \
     libavahi-compat-libdnssd-dev \
     libboost-all-dev \
+    libncurses5-dev \
     libsndfile1-dev \
     libssl-dev \
     libtool \


### PR DESCRIPTION
I needed it to move a 2019.02 buildroot build forward on linuxdev18 using this image.