### PR TITLE
Dockerfile: Upgrade Node.JS from 12.x to 15.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update \
   #&& curl -sL https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add - \
   #&& apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main' \
   # Use NodeSource's NodeJS 12.x repository
-  && curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+  && curl -sL https://deb.nodesource.com/setup_15.x | bash - \
   # Install nvm binary
   && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash \
   # Install nodejs/npm


### PR DESCRIPTION
We should keep our tools up to date, and the package-lock.json file has been upgraded in its format in npm v7.x (which comes with Node 15.x). It can still handle older package-lock.json format files too.