### PR TITLE
Add armv7 Linux rustup target, use rustup "add" instead of "install"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,8 @@ cargo install cargo-deny
 cargo install cargo-license
 cargo install cargo-lichking
 cargo install cargo-script
-rustup target install x86_64-unknown-linux-musl
+rustup target add x86_64-unknown-linux-musl
+rustup target add armv7-unknown-linux-gnueabihf
 rm -rf "$RUST_HOME/registry" "$RUST_HOME/git"
 chmod 777 "$RUST_HOME"
 apt-get install -y musl-tools


### PR DESCRIPTION
I need the armv7-unknown-linux-gnueabihf Rust target to build yNodes using this Docker image.